### PR TITLE
Added another example and fixed MemrefPat and MemptrPat

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ Herast helps with finding AST subtrees and with following work with found items.
 
 ## Installation
 
-- Place `herast/` to `$IDA_DIR/python/3/` directory
-- Place `herapi.py` to `$IDA_DIR/python/3/` directory
-- Place `herast.py` to `$IDA_DIR/plugins` directory
+\$IDAUSR is "%APPDATA%/Hex-Rays/IDA Pro" on windows and "$HOME/.idapro" on linux and mac
+
+- Place `herast/` to `$IDAUSR/python/3/` directory
+- Place `herapi.py` to `$IDAUSR/python/3/` directory
+- Place `herast.py` to `$IDAUSR/plugins` directory
 
 ## Use already written AST handlers
 

--- a/examples/passives/string_dtor.py
+++ b/examples/passives/string_dtor.py
@@ -1,0 +1,102 @@
+from herapi import *
+
+
+class StringDtorScheme(Scheme):
+	def __init__(self):
+		"""
+		pattern of a combination of the forms:
+		if ( v16.capacity >= 0x10)
+		{
+			v12 = *(void **)v16.str_or_ptr;
+			if ( (unsigned __int64)(v16.capacity + 1) >= 0x1000 )
+			{
+
+			}
+			j_j_free(v12);
+		}
+		or
+		if ( v16 >= 0x10)
+		{
+			v12 = *(void **)v15;
+			if ( (unsigned __int64)(v16 + 1) >= 0x1000 )
+			{
+
+			}
+			j_j_free(v15);
+		}
+		how destruction of a string inline usually happens
+		"""
+		pattern = IfPat(
+					UgePat(
+						OrPat(
+							VarPat(),
+							MemrefPat(
+								VarPat()
+							),
+						),
+						NumPat(0x10)
+					),
+					BlockPat(
+						AsgInsnPat(
+							VarBindPat("free_var"),
+							OrPat(
+								PtrPat(
+									MemrefPat(
+										VarBindPat("str_as_str")
+									)
+								),
+								PtrPat(
+									VarBindPat("str_as_str")
+								),
+								VarBindPat("reg_str"),
+								skip_casts=True
+							)
+						),
+						IfPat(
+							UgePat(
+								OrPat(
+									AddPat(
+										VarPat(),
+										NumPat(1)
+									),
+									AddPat(
+										MemrefPat(
+											VarPat()
+										),
+										NumPat(1)
+									),
+									skip_casts=True
+								),
+								NumPat(0x1000),
+							),
+						),
+						CallInsnPat(
+							AnyPat(),
+							OrPat(
+								VarBindPat("free_var"),
+								VarBindPat("str_as_str")
+							),
+						)
+					)
+				)
+		name = "string_dtor"
+		super().__init__(name, pattern)
+
+	def on_matched_item(self, item, ctx: PatternContext):
+		str_as_str = ctx.get_var("str_as_str")
+		str_as_var = ctx.get_var("str_as_var")
+		var = None
+		if str_as_str is None:
+			if str_as_var is None:
+				return False
+			else:
+				var = str_as_var
+		else:
+			var = str_as_str
+
+		new_item = make_call_helper_instr("string_dtor", var)
+		ctx.modify_instr(item, new_item)
+		return False
+
+
+register_storage_scheme(StringDtorScheme())

--- a/herast/tree/patterns/expressions.py
+++ b/herast/tree/patterns/expressions.py
@@ -184,15 +184,15 @@ class MemrefPat(ExpressionPat):
 	"""Pattern for matching memory references."""
 	op = idaapi.cot_memref
 
-	def __init__(self, referenced_object, field, **kwargs):
+	def __init__(self, referenced_object, field=None, **kwargs):
 		super().__init__(**kwargs)
 		self.referenced_object = referenced_object
 		self.field = field
 
 	@ExpressionPat.parent_check
 	def check(self, expression, ctx: PatternContext) -> bool:
-		return self.referenced_object.check(expression.x, ctx) and \
-			self.field.check(expression.m, ctx)
+		return (self.field is None or self.field == expression.m) and \
+			self.referenced_object.check(expression.x, ctx)
 
 
 class PtrPat(ExpressionPat):
@@ -211,15 +211,15 @@ class MemptrPat(ExpressionPat):
 	"""Pattern for matching memory pointers."""
 	op = idaapi.cot_memptr
 
-	def __init__(self, pointed_object, field, **kwargs):
+	def __init__(self, pointed_object, field=None, **kwargs):
 		super().__init__(**kwargs)
 		self.pointed_object = pointed_object
 		self.field = field
 
 	@ExpressionPat.parent_check
 	def check(self, expression, ctx: PatternContext) -> bool:
-		return self.pointed_object.check(expression.x, ctx) and \
-			self.field.check(expression.m, ctx)
+		return (self.field is None or self.field == expression.m) and \
+			self.pointed_object.check(expression.x, ctx)
 
 
 class IdxPat(ExpressionPat):

--- a/herast/tree/patterns/instructions.py
+++ b/herast/tree/patterns/instructions.py
@@ -68,7 +68,7 @@ class IfPat(InstructionPat):
 			if pat is None:
 				return AnyPat()
 
-			if not should_wrap_in_block:
+			if not should_wrap_in_block or isinstance(pat, AnyPat):
 				return pat
 
 			if pat.op == idaapi.cit_block:


### PR DESCRIPTION
Changed the directory structure to add the plugin into the ida user directory so all ida versions will use the plugin without copying it into each installation's folder.
Added AnyPat to not be wrapped by block in IfPat.
There was a bug in MemrefPat and MemptrPat,
because expression.m was passed to check which first calls parent check and tries to access the op of item but item was an uint32
https://hex-rays.com/products/decompiler/manual/sdk/hexrays_8hpp_source.shtml#l06099
Also added another example to simplify inline string destructors